### PR TITLE
Fix detecting internal IP in RouterOS containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ EE_DOMAIN=\${EE_DOMAIN:-}
 MAX_CONNECTIONS=\${MAX_CONNECTIONS:-60000}
 
 # Detect container-local IPv4 for NAT (used when EXTERNAL_IP is provided).
-LOCAL_IP=\$(grep -vE '(local|ip6|^fd)' /etc/hosts | awk 'NR==1 {print \$1}')
+LOCAL_IP=\$(grep -vE '(local|ip6|^fd|^\$)' /etc/hosts | awk 'NR==1 {print \$1}')
 
 # Optional public IPv4 address to advertise to Telegram DCs; pass via -e EXTERNAL_IP=1.2.3.4
 EXTERNAL_IP=\${EXTERNAL_IP:-}


### PR DESCRIPTION
Some OSes like RouterOS containers put empty lines in /etc/hosts like:
```
127.0.0.1 localhost
::1        localhost ip6-localhost ip6-loopback
fe00::0    ip6-localnet
ff00::0    ip6-mcastprefix
ff02::1    ip6-allnodes
ff02::2    ip6-allrouters

172.17.0.3 tgproxy2
```
And this line in start.sh doesn't work:
`LOCAL_IP=$(grep -vE '(local|ip6|^fd)' /etc/hosts | awk 'NR==1 {print $1}')`
Grep gets the first empty line and awk extracts nothing.
This will lead to a problem with detecting the internal IP with NAT configurations.

I suggest to fix it with skipping empty lines too:
`grep -vE '(local|ip6|^fd|^$)'`
This construction works fine in RouterOS containers.